### PR TITLE
Don't replace field when looking up values

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ the high level:
   has multiple tuning parameters. Note that the clustering algorithm (DBSCAN)
   is non-deterministic; results will vary on each run
 * `group_by` groups rows of a CSV by values in a particular column
-* `lookup` replaces "id"s with their names based on a lookup file
+* `lookup` replaces "id"s with their names based on a lookup file; adds a new
+  column for the result
 
 ### Examples
 
@@ -114,14 +115,14 @@ cat dataset.csv \
   | group_by --min-group-size 2 --accumulation-field name
 ```
 
-A second method of achieving the same result would be to "lookup" the dataset
+A second method of achieving a similar result would be to "lookup" the dataset
 names by referencing their ids:
 
 ```
 cat dataset.csv \
   | cluster_by_field \
   | group_by --min-group-size 2 \
-  | lookup --lookup-file dataset.csv --replacement-field id
+  | lookup --lookup-file dataset.csv --source-field id
 ```
 
 * `lookup` converts ids from one CSV into their respective values, using a
@@ -129,8 +130,11 @@ cat dataset.csv \
   the other two have reasonable defaults.
   * `lookup-file` the file name we'll be using to find id-value pairs.
     "dataset.csv" in the above example
-  * `replacement-field` the CSV column that contains ids we want to replace.
+  * `source-field` the CSV column that contains ids we want to replace.
     We expect those ids to be comma-separated
+  * `destination-field` the CSV column to write the replacement to. This
+    defaults to "values", and will replace another column if there's a name
+    collision
   * `id-field` the CSV column that contains the ids in the lookup-file.
     Defaults to "id"
   * `value-field` the CSV column that contains the value in the lookup-file.
@@ -170,12 +174,12 @@ if we two datasets, one with fields "SSN" and "First Name" and another with
 ```
 cat vars.csv \
   | cluster_by_field --field vname --group-field field_cluster \
-  | group_by --group-field dsids --accumulation-fields field_cluster \
+  | group_by --group-field dsids --accumulation-field field_cluster \
   | cluster_by_field --field field_cluster --field-split comma \
     --group-field dataset_cluster \
   | group_by --min-group-size 2 --group-field dataset_cluster \
     --accumulation-field dsids \
-  | lookup --lookup-file dataset.csv --replacement-field dsids
+  | lookup --lookup-file dataset.csv --source-field dsids
 ```
 
 Let's break that down -- we'll skim over pieces explained in the previous

--- a/census_similarity/commands/cluster_by_field.py
+++ b/census_similarity/commands/cluster_by_field.py
@@ -33,7 +33,7 @@ def cluster_by_field(
     INPUT_FILE - CSV to read from, defaults to stdin
     OUTPUT_FILE - CSV to write to, defaults to stdout"""
     all_rows, writer = read_csv_write_header(
-        input_file, output_file, [field], lambda hdr: hdr + [group_field])
+        input_file, output_file, [field], group_field)
 
     splitter = getattr(splits, field_split)
     metric = getattr(metrics, distance_metric)

--- a/census_similarity/commands/lookup.py
+++ b/census_similarity/commands/lookup.py
@@ -12,22 +12,25 @@ from census_similarity.io import read_csv_write_header, read_rows
                 default=sys.stdout)
 @click.option('--lookup-file', type=click.File('rt'),
               help='File which contains lookup values')
-@click.option('--replacement-field', help='Field to replace ids with')
+@click.option('--source-field', help='Which field to look for ids')
+@click.option('--destination-field', help='Where to write replacement',
+              default='values')
 @click.option('--id-field', default='id',
               help="Field name in lookup-file we'll be replacing")
 @click.option('--value-field', default='name',
               help='Field name in lookup-file to replace with')
-def lookup(input_file, output_file, lookup_file, replacement_field, id_field,
-           value_field):
+def lookup(input_file, output_file, lookup_file, source_field,
+           destination_field, id_field, value_field):
     """Given a CSV, replace lookup values. The input file should contain a
     column of ids which are explained in the lookup-file. This command will
-    replace those ids with names found in the lookup-file.
+    add a column to the CSV with those ids replaced with values found in the
+    lookup-file.
 
     \b
     INPUT_FILE - CSV to read from, defaults to stdin
     OUTPUT_FILE - CSV to write to, defaults to stdout"""
     all_rows, writer = read_csv_write_header(
-        input_file, output_file, [replacement_field])
+        input_file, output_file, [source_field], destination_field)
 
     lookup = {}
     lookup_rows, _ = read_rows(lookup_file, [id_field, value_field])
@@ -37,7 +40,7 @@ def lookup(input_file, output_file, lookup_file, replacement_field, id_field,
         lookup[key] = value
 
     for row in all_rows:
-        ids = [i.strip() for i in row[replacement_field].split(',')]
+        ids = [i.strip() for i in row[source_field].split(',')]
         values = [lookup.get(i, '') for i in ids]
-        row[replacement_field] = ','.join(values)
+        row[destination_field] = ','.join(values)
         writer.writerow(row)

--- a/census_similarity/io.py
+++ b/census_similarity/io.py
@@ -28,11 +28,14 @@ def read_csv_write_header(
     :param header:
         if None, use the input_file's header.
         if a callable, apply it to the input_file's header.
+        if a string, append it to the input_file's header (if not present)
         else, assume the header is a sequence of strings
     :return: pair of list of dicts (rows in the CSV), and a csv.DictWriter"""
     all_rows, fieldnames = read_rows(input_file, expected_fields)
-    if header is None:
+    if header is None or (isinstance(header, str) and header in fieldnames):
         header = fieldnames
+    elif isinstance(header, str):
+        header = fieldnames + [header]
     elif callable(header):
         header = header(fieldnames)
 


### PR DESCRIPTION
Rather than replacing a column full of ids with the same column full of
looked-up values, allow the user to create a _new_ column.
